### PR TITLE
(fix): Resource leaks on deserializeFromString

### DIFF
--- a/terracotta/bootstrap/src/main/java/org/terracotta/quartz/collections/SerializationHelper.java
+++ b/terracotta/bootstrap/src/main/java/org/terracotta/quartz/collections/SerializationHelper.java
@@ -44,8 +44,9 @@ public class SerializationHelper {
 
   public static Object deserializeFromString(String key) throws IOException, ClassNotFoundException {
     if (key.length() >= 1 && key.charAt(0) == MARKER) {
-      ObjectInputStream ois = new ObjectInputStream(new StringSerializedObjectInputStream(key));
-      return ois.readObject();
+      try(ObjectInputStream ois = new ObjectInputStream(new StringSerializedObjectInputStream(key))) {
+        return ois.readObject();
+      }
     }
 
     return key;


### PR DESCRIPTION
This line of code contains a resource that might not be closed properly. This can cause a resource leak that slows down or crashes your system.